### PR TITLE
installing on windows crashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "preversion": "",
     "version": "git add CHANGELOG.md",
     "postversion": "git push && git push --tags",
-    "postinstall": "scripts/install.js",
+    "postinstall": "node ./scripts/install.js",
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "run:packager": "./node_modules/react-native/packager/packager.sh",
     "run:ios": "react-native run-ios --project-path ./example/ios",


### PR DESCRIPTION
> react-native-nearby-api@0.0.5 postinstall D:\Projects\swabit\swabit.app\node_modules\react-native-nearby-api
> scripts/install.js

'scripts' is not recognized as an internal or external command,